### PR TITLE
Fix base path for preview deployments

### DIFF
--- a/components/blocks/Meta.js
+++ b/components/blocks/Meta.js
@@ -1,6 +1,10 @@
 import Head from "next/head";
 
 export default function Meta({ title, description, social }) {
+  const basePath = process.env.NEXT_PUBLIC_VERCEL_URL
+    ? "https://" + process.env.NEXT_PUBLIC_VERCEL_URL
+    : "";
+
   return (
     <Head>
       <title>{title}</title>
@@ -8,10 +12,7 @@ export default function Meta({ title, description, social }) {
       <meta property="og:title" content={title}></meta>
       <meta property="og:site_name" content="neurodiversity.wiki"></meta>
       <meta property="og:description" content={description}></meta>
-      <meta
-        property="og:image"
-        content={"https://neurodiversity.wiki" + social}
-      ></meta>
+      <meta property="og:image" content={basePath + social}></meta>
       <meta name="twitter:card" content="summary_large_image"></meta>
       <meta name="twitter:site" content="@alvarlagerlof"></meta>
       <meta name="twitter:creator" content="@alvarlagerlof"></meta>


### PR DESCRIPTION
For preview deploys, og:image was broken for new pages becasue it was looking for images on production instead of the preview url.