### PR TITLE
.github/dependabot: add initial configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm" # Use npm for the package ecosystem
+    directory: "/" # Location of package manifests (package.json, package-lock.json)
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/" # Location of package manifests (package.json, package-lock.json)
     schedule:
       interval: "daily"
+    reviewers:
+      - "alvarlagerlof"


### PR DESCRIPTION
Automatically upgrades dependencies.

We're using Yarn and not npm, but the `package-ecosystem` should still be
just `npm`, for reference see https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#package-ecosystem