### PR TITLE
Fix LinkGridItem bottom margin

### DIFF
--- a/app/components/LinkGridItem.tsx
+++ b/app/components/LinkGridItem.tsx
@@ -52,7 +52,7 @@ export function LinkGridItem({ href, title, description }: Props) {
                 {title}
               </Link>
             </Typography.Heading>
-            <Typography.Body className="mb-0">{description}</Typography.Body>
+            <Typography.Body className="!mb-0">{description}</Typography.Body>
           </div>
         </div>
       </Bounce>


### PR DESCRIPTION
Was adding extra margin to the bottom via Typography.Body.